### PR TITLE
Do not add root page if only languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatsby-plugin-intl",
-  "version": "5.8.1",
+  "version": "5.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatsby-plugin-intl",
-      "version": "5.8.1",
+      "version": "5.8.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.21.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-plugin-intl",
   "description": "Gatsby plugin to add react-intl onto a site",
-  "version": "5.8.1",
+  "version": "5.8.2",
   "author": "Daewoong Moon <wiziple@gmail.com>",
   "bugs": {
     "url": "https://github.com/wiziple/gatsby-plugin-intl"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gatsby-plugin-intl",
+  "name": "thompsonsj-gatsby-plugin-intl",
   "description": "Gatsby plugin to add react-intl onto a site",
-  "version": "5.8.2",
+  "version": "5.8.3",
   "author": "Daewoong Moon <wiziple@gmail.com>",
   "bugs": {
     "url": "https://github.com/wiziple/gatsby-plugin-intl"

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -96,7 +96,7 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
 
   deletePage(page)
 
-  if (onlyLanguages.length === 0 || onlyLanguages.includes(defaultLanguage)) {
+  if (onlyLanguages.length === 0) {
     const newPage = generatePage(false, defaultLanguage)
     createPage(newPage)
   }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -96,7 +96,7 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
 
   deletePage(page)
 
-  if (onlyLanguages.length === 0) {
+  if (onlyLanguages.length === 0 || onlyLanguages.length === languages.length) {
     const newPage = generatePage(false, defaultLanguage)
     createPage(newPage)
   }


### PR DESCRIPTION
If `onlyLanguages` is set then creating a root version of the page doesn't make much sense: the sitemap will report links such as `https://www.mydomain.com/article-in-de-only`. These links will often lead to a 404 when the site tries to redirect to an appropriate language.

Excluding these root pages reduces invalid links in the sitemap.

## Follow up

Is it possible or advisable to add an option that prevents these root pages being created? Appropriate redirects should be in place when using language folders.