### PR TITLE
feat(gatsbynode): disable root page generation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,15 @@ languages | string[] | supported language keys
 defaultLanguage | string | default language when visiting `/page` instead of `ko/page`
 redirect | boolean | if the value is `true`, `/` or `/page-2` will be redirected to the user's preferred language router. e.g) `/ko` or `/ko/page-2`. Otherwise, the pages will render `defaultLangugage` language.
 redirectComponent | string (optional) | additional component file path to be rendered on with a redirection component for SEO.
+disableRootPages | boolean (optional) | if the value is `true`, `/` or `/page-2` will not be created. Use if you are using your own redirect rules. Useful in scenarios where page creation should be avoided - e.g. sitemap generation. 
 
+## Page specific options
+
+Pass the following within a `gatsbyPluginIntl` object in [page context](https://www.gatsbyjs.com/docs/creating-and-modifying-pages/#pass-context-to-pages).
+
+Option | Type | Description
+-- | -- | --
+onlyLanguages | array | only generate the page in the specified languages.
 
 ## Components
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'gatsby-plugin-intl' {
+declare module 'thompsonsj-gatsby-plugin-intl' {
   import * as gatsby from 'gatsby';
   import React from 'react';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thompsonsj-gatsby-plugin-intl",
   "description": "Gatsby plugin to add react-intl onto a site",
-  "version": "5.8.4",
+  "version": "5.8.6",
   "author": "Daewoong Moon <wiziple@gmail.com>",
   "bugs": {
     "url": "https://github.com/wiziple/gatsby-plugin-intl"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thompsonsj-gatsby-plugin-intl",
   "description": "Gatsby plugin to add react-intl onto a site",
-  "version": "5.8.3",
+  "version": "5.8.4",
   "author": "Daewoong Moon <wiziple@gmail.com>",
   "bugs": {
     "url": "https://github.com/wiziple/gatsby-plugin-intl"

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -49,6 +49,7 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
     languages = ["en"],
     defaultLanguage = "en",
     redirect = false,
+    disableRootPages = false,
   } = pluginOptions
 
   const getMessages = (path, language) => {
@@ -96,7 +97,7 @@ exports.onCreatePage = async ({ page, actions }, pluginOptions) => {
 
   deletePage(page)
 
-  if (onlyLanguages.length === 0 || onlyLanguages.length === languages.length) {
+  if (!disableRootPages && (onlyLanguages.length === 0 || onlyLanguages.length === languages.length)) {
     const newPage = generatePage(false, defaultLanguage)
     createPage(newPage)
   }


### PR DESCRIPTION
Add a `disableRootPages` plugin option to disable the generation of pages such as `/` or `page-2`. Docs included in README.