### PR TITLE
fix(indexdts): fix not a module error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'gatsby-plugin-intl' {
+declare module 'thompsonsj-gatsby-plugin-intl' {
   import * as gatsby from 'gatsby';
   import React from 'react';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thompsonsj-gatsby-plugin-intl",
   "description": "Gatsby plugin to add react-intl onto a site",
-  "version": "5.8.3",
+  "version": "5.8.4",
   "author": "Daewoong Moon <wiziple@gmail.com>",
   "bugs": {
     "url": "https://github.com/wiziple/gatsby-plugin-intl"


### PR DESCRIPTION
Without this change, we do not get types and get a warning for every import.

<img width="656" height="360" alt="Screenshot 2025-11-18 at 10 13 23" src="https://github.com/user-attachments/assets/51dd25f5-8e40-457a-ac71-87bb537ca35a" />

