### PR TITLE
fix(packagejson): bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "thompsonsj-gatsby-plugin-intl",
   "description": "Gatsby plugin to add react-intl onto a site",
-  "version": "5.8.4",
+  "version": "5.8.5",
   "author": "Daewoong Moon <wiziple@gmail.com>",
   "bugs": {
     "url": "https://github.com/wiziple/gatsby-plugin-intl"


### PR DESCRIPTION
https://github.com/thompsonsj/gatsby-plugin-intl/pull/4 did not publish until this version bump was made. Keep the `package.json` version in sync with the published versions on npm.

No need to automate this with CI or package scripts. This is a basic package which is likely to be archived soon.